### PR TITLE
Add dependency checks and cleaned requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,10 @@ torch
 trl
 einops
 peft
-pytest
 sentencepiece
+
+# --- Testing ---
+pytest
 
 # --- Shared Libraries ---
 sentence-transformers
@@ -33,7 +35,6 @@ pyarrow
 tqdm
 requests
 langdetect
-pytest
 evaluate
 rouge_score
 jupyterlab

--- a/scripts/explore_raw_data.py
+++ b/scripts/explore_raw_data.py
@@ -1,12 +1,25 @@
 # scripts/explore_raw_data.py
 
-import pandas as pd
+"""Generate a diagnostics report for the raw data files."""
+
+import importlib
+import sys
 from pathlib import Path
 import zipfile
 import io
 import ast
 from collections import Counter
 from contextlib import redirect_stdout
+
+REQUIRED_PACKAGES = ["pandas", "pyarrow"]
+
+for pkg in REQUIRED_PACKAGES:
+    if importlib.util.find_spec(pkg) is None:
+        sys.exit(
+            f"Missing required package '{pkg}'. Install dependencies via 'pip install -r requirements.txt'."
+        )
+
+import pandas as pd
 
 # --- CONFIGURATION ---
 RAW_DATA_ROOT = Path("data/1_raw_source_data")

--- a/scripts/generate_review_sheet.py
+++ b/scripts/generate_review_sheet.py
@@ -2,10 +2,23 @@
 # A simple, assumption-free script to generate distractors for human review.
 # This script does NOT look for a 'choices' column.
 
+"""Generate a CSV of model-generated distractors for manual review."""
+
+import importlib
+import sys
+from pathlib import Path
+
+REQUIRED_PACKAGES = ["pandas", "pyarrow", "torch", "transformers", "tqdm"]
+
+for pkg in REQUIRED_PACKAGES:
+    if importlib.util.find_spec(pkg) is None:
+        sys.exit(
+            f"Missing required package '{pkg}'. Install dependencies via 'pip install -r requirements.txt'."
+        )
+
 import pandas as pd
 import torch
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
-from pathlib import Path
 from tqdm import tqdm
 
 # --- Configuration (using files we KNOW exist) ---

--- a/scripts/investigate_data.py
+++ b/scripts/investigate_data.py
@@ -1,9 +1,22 @@
 # investigate_data.py
 # A robust script to find and analyze rows in the dataset based on column length.
 
-import pandas as pd
+"""Utility to explore dataset rows based on column length."""
+
+import importlib
+import sys
 import argparse
 import os
+
+REQUIRED_PACKAGES = ["pandas", "pyarrow"]
+
+for pkg in REQUIRED_PACKAGES:
+    if importlib.util.find_spec(pkg) is None:
+        sys.exit(
+            f"Missing required package '{pkg}'. Install dependencies via 'pip install -r requirements.txt'."
+        )
+
+import pandas as pd
 
 # --- Configuration ---
 DEFAULT_DATA_FILE = "data/processed/ALL_PSYCHOLOGY_DATA_normalized.parquet"

--- a/scripts/verify_training_data.py
+++ b/scripts/verify_training_data.py
@@ -1,6 +1,19 @@
-import pandas as pd
+"""Spot-check quality of generated training data."""
+
+import importlib
+import sys
 import os
 import argparse
+
+REQUIRED_PACKAGES = ["pandas", "pyarrow"]
+
+for pkg in REQUIRED_PACKAGES:
+    if importlib.util.find_spec(pkg) is None:
+        sys.exit(
+            f"Missing required package '{pkg}'. Install dependencies via 'pip install -r requirements.txt'."
+        )
+
+import pandas as pd
 
 # --- Configuration ---
 TRAINING_DATA_FILE = "data/training_sets/distractor_generation_training_data.parquet"


### PR DESCRIPTION
## Summary
- add runtime dependency checks to scripts
- clean up script endings
- ensure requirements.txt lists pandas, pyarrow, transformers, torch and others

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68843997dc3083288cbe42bd9b8a24a2